### PR TITLE
Add definitions of ItemData and ItemAffixData structs + one enum used for affixes

### DIFF
--- a/enums.h
+++ b/enums.h
@@ -568,6 +568,17 @@ typedef enum {
 	ITEM_TYPE_NONE         = -1,
 } item_type;
 
+// Bit flag which is used to determine if affix could be applied to certain type of items.
+// As it can be noted each flag just represents one or more values from `item_type` enumeration.
+typedef enum {
+    AFFIX_ITEM_TYPE_JEWELRY = 0x1     ,
+    AFFIX_ITEM_TYPE_BOW     = 0x10    ,
+    AFFIX_ITEM_TYPE_STAFF   = 0x100   ,
+    AFFIX_ITEM_TYPE_WEAPON  = 0x1000  ,
+    AFFIX_ITEM_TYPE_SHIELD  = 0x10000 ,
+    AFFIX_ITEM_TYPE_ARMOR   = 0x100000,
+} affix_item_type;
+
 // Tile IDs for dungeon layout 1.
 //
 // TODO: Figure out how to fix broken link. Requires graphics files, which may

--- a/enums.h
+++ b/enums.h
@@ -7,12 +7,12 @@ typedef enum {
 	DAMAGE_TYPE_ACID      = 4,
 } damage_type;
 
-// Drop rates.
+// Item drop rates.
 typedef enum {
-	DROP_RATE_NEVER   = 0, // never drops.
-	DROP_RATE_REGULAR = 1, // regular drop change.
-	DROP_RATE_DOUBLE  = 2, // twice as likely to drop.
-} drop_rate;
+	ITEM_DROP_RATE_NEVER   = 0, // never drops.
+	ITEM_DROP_RATE_REGULAR = 1, // regular drop change.
+	ITEM_DROP_RATE_DOUBLE  = 2, // twice as likely to drop.
+} item_drop_rate;
 
 // Dungeon types.
 typedef enum {
@@ -70,45 +70,45 @@ typedef enum {
 // References:
 //    * https://github.com/sanctuary/notes/blob/master/structs.h#item
 typedef enum {
-	ITEM_CATEGORY_NONE                   = 0,
-	ITEM_CATEGORY_WEAPON                 = 1,
-	ITEM_CATEGORY_ARMOR                  = 2,
-	ITEM_CATEGORY_JEWELRY_AND_CONSUMABLE = 3,
-	ITEM_CATEGORY_GOLD                   = 4,
-	ITEM_CATEGORY_QUEST                  = 5,
-} item_category;
+	ITEM_CLASS_NONE                   = 0,
+	ITEM_CLASS_WEAPON                 = 1,
+	ITEM_CLASS_ARMOR                  = 2,
+	ITEM_CLASS_JEWELRY_AND_CONSUMABLE = 3,
+	ITEM_CLASS_GOLD                   = 4,
+	ITEM_CLASS_QUEST                  = 5,
+} item_class;
 
 // Additional item categorization.
 //
 // References:
 //    * https://github.com/sanctuary/notes/blob/master/structs.h#item
 typedef enum {
-	ITEM_CODE_NONE                        =  0, // all non-unique weapons and armor have this code
-	ITEM_CODE_USE_FIRST                   =  1, // unused
-	ITEM_CODE_POTION_OF_FULL_HEALING      =  2,
-	ITEM_CODE_POTION_OF_HEALING           =  3,
-	ITEM_CODE_POTION_OF_MANA              =  6,
-	ITEM_CODE_POTION_OF_FULL_MANA         =  7,
-	ITEM_CODE_ELIXIR_OF_STRENGTH          = 10,
-	ITEM_CODE_ELIXIR_OF_MAGIC             = 11,
-	ITEM_CODE_ELIXIR_OF_DEXTERITY         = 12,
-	ITEM_CODE_ELIXIR_OF_VITALITY          = 13,
-	ITEM_CODE_POTION_OF_REJUVENATION      = 18,
-	ITEM_CODE_POTION_OF_FULL_REJUVENATION = 19,
-	ITEM_CODE_USE_LAST                    = 20, // unused
-	ITEM_CODE_SCROLL                      = 21,
-	ITEM_CODE_SCROLL_WITH_TARGET          = 22,
-	ITEM_CODE_STAFF                       = 23,
-	ITEM_CODE_BOOK                        = 24,
-	ITEM_CODE_RING                        = 25,
-	ITEM_CODE_AMULET                      = 26,
-	ITEM_CODE_UNIQUE                      = 27,
-	ITEM_CODE_POTION_OF_HEALING_SOMETHING = 28, // unused
-	ITEM_CODE_MAP_OF_THE_STARS            = 42,
-	ITEM_CODE_EAR                         = 43,
-	ITEM_CODE_SPECTRAL_ELIXIR             = 44,
-	ITEM_CODE_INVALID                     = -1,
-} item_code;
+	ITEM_MISC_ID_NONE                        =  0, // all non-unique weapons and armor have this code
+	ITEM_MISC_ID_USE_FIRST                   =  1, // unused
+	ITEM_MISC_ID_POTION_OF_FULL_HEALING      =  2,
+	ITEM_MISC_ID_POTION_OF_HEALING           =  3,
+	ITEM_MISC_ID_POTION_OF_MANA              =  6,
+	ITEM_MISC_ID_POTION_OF_FULL_MANA         =  7,
+	ITEM_MISC_ID_ELIXIR_OF_STRENGTH          = 10,
+	ITEM_MISC_ID_ELIXIR_OF_MAGIC             = 11,
+	ITEM_MISC_ID_ELIXIR_OF_DEXTERITY         = 12,
+	ITEM_MISC_ID_ELIXIR_OF_VITALITY          = 13,
+	ITEM_MISC_ID_POTION_OF_REJUVENATION      = 18,
+	ITEM_MISC_ID_POTION_OF_FULL_REJUVENATION = 19,
+	ITEM_MISC_ID_USE_LAST                    = 20, // unused
+	ITEM_MISC_ID_SCROLL                      = 21,
+	ITEM_MISC_ID_SCROLL_WITH_TARGET          = 22,
+	ITEM_MISC_ID_STAFF                       = 23,
+	ITEM_MISC_ID_BOOK                        = 24,
+	ITEM_MISC_ID_RING                        = 25,
+	ITEM_MISC_ID_AMULET                      = 26,
+	ITEM_MISC_ID_UNIQUE                      = 27,
+	ITEM_MISC_ID_POTION_OF_HEALING_SOMETHING = 28, // unused
+	ITEM_MISC_ID_MAP_OF_THE_STARS            = 42,
+	ITEM_MISC_ID_EAR                         = 43,
+	ITEM_MISC_ID_SPECTRAL_ELIXIR             = 44,
+	ITEM_MISC_ID_INVALID                     = -1,
+} item_misc_id;
 
 // TODO: Rethink item_drop_state enum. It probably has to do with animation, and
 // then ITEM_DROP_STATE_GLIMMERING would make sense, as that would be

--- a/structs.h
+++ b/structs.h
@@ -24,8 +24,8 @@ typedef struct {
 // Item describes in-game state of any game item.
 //
 // References:
-//    * https://github.com/sanctuary/notes/blob/master/enums.h#item_category
-//    * https://github.com/sanctuary/notes/blob/master/enums.h#item_code
+//    * https://github.com/sanctuary/notes/blob/master/enums.h#item_class
+//    * https://github.com/sanctuary/notes/blob/master/enums.h#item_misc_id
 //    * https://github.com/sanctuary/notes/blob/master/enums.h#item_drop_state
 //    * https://github.com/sanctuary/notes/blob/master/enums.h#item_effect_type
 //    * https://github.com/sanctuary/notes/blob/master/enums.h#item_equip_type
@@ -74,7 +74,7 @@ typedef struct { // size = 0x170
     // offset 00BD (1 byte)
     item_equip_type equip_type;
     // offset 00BE (1 byte)
-    item_category category;
+    item_class _class;
     // offset 00C0 (4 bytes)
     item_inv_graphics_id inv_graphics_id;
     // offset 00C4 (4 bytes)
@@ -90,7 +90,7 @@ typedef struct { // size = 0x170
     // offset 00D8 (4 bytes)
     item_special_effect special_effect_flags; // bitmask
     // offset 00DC (4 bytes)
-    item_code code;
+    item_misc_id misc_id;
     // offset 00E0 (4 bytes)
     spell_id item_spell_id;
     // offset 00E4 (4 bytes)
@@ -172,6 +172,65 @@ typedef struct { // size = 0x170
     // offset 0168 (4 byte)
     item_id id;
 } Item;
+
+// ItemData describes possible basic state a of game item (i.e. state before possibly applying
+// prefix, suffix, unique, effects or spells for books or staves)
+typedef struct // size = 0x4C
+{
+    // offset 0000 (4 bytes)
+    item_drop_rate drop_rate;
+    // offset 0004 (1 byte)
+    item_class _class;
+    // offset 0005 (1 byte)
+    item_equip_type equip_type;
+    // offset 0008 (4 bytes)
+    item_inv_graphics_id inv_graphics_id;
+    // offset 000C (1 byte)
+    item_type type;
+    // offset 000D (1 byte)
+    unique_base_item unique_base_item_id;
+    // offset 0010 (4 bytes)
+    const char *name;
+    // offset 0014 (4 bytes)
+    const char *short_name; // applied if item description becomes too long after adding affixes
+                            // and/or spell
+    // offset 0018 (4 bytes)
+    item_quality quality;
+    // offset 001C (4 bytes)
+    int max_durability;
+    // offset 0020 (4 bytes)
+    int min_attack_damage;
+    // offset 0024 (4 bytes)
+    int max_attack_damage;
+    // offset 0028 (4 bytes)
+    int min_armor_class;
+    // offset 002C (4 bytes)
+    int max_armor_class;
+    // offset 0030 (1 byte)
+    uint8_t required_strength;
+    // offset 0031 (1 byte)
+    uint8_t required_magic;
+    // offset 0032 (1 byte)
+    uint8_t required_dexterity;
+    // offset 0034 (4 bytes)
+    item_special_effect special_effect_flags; // Rarely set, only for undead crown and even this
+                                              // case seems to be redundant due one of its unique
+                                              // item effect
+    // offset 0038 (4 bytes)
+    item_misc_id misc_id;
+    // offset 003C (4 bytes)
+    spell_id spell_id; // Used for charges on Short Staff of Charged Bolt,
+                       // and used for scrolls otherwise.
+    // offset 0040 (4 bytes)
+    bool32_t is_usable; // Set if item could be triggered with right click (e.g. for gold,
+                        // potions, elixirs, books and scrolls). Some unique items do still
+                        // trigger an action on right click even though for them this flag
+                        // is not set.
+    // offset 0044 (4 bytes)
+    int price;
+    // offset 0048 (4 bytes)
+    int max_price; // Unused but for all items is specified higher than price
+} ItemData;
 
 // A Point is an X, Y coordinate pair. The axes increase right and down.
 typedef struct {

--- a/structs.h
+++ b/structs.h
@@ -232,6 +232,49 @@ typedef struct // size = 0x4C
     int max_price; // Unused but for all items is specified higher than price
 } ItemData;
 
+// ItemEffect describes possible effect caused by suffix or prefix of magic item or one of
+// 5 unique item's effects. For some rare effect types min/max values represent different
+// type of parameters.
+typedef struct {
+	item_effect_type type;
+	int32_t min_value;
+	int32_t max_value;
+} ItemEffect;
+
+// ItemAffixData describes effect and properties of affix with listed name.
+//
+// References:
+// * https://github.com/sanctuary/notes/blob/master/rdata/items.cpp#item_prefix_data
+// * https://github.com/sanctuary/notes/blob/master/rdata/items.cpp#item_suffix_data
+typedef struct // size = 0x30
+{
+    // offset 0000 (4 bytes)
+    const char *name;
+    // offset 0004 (12 bytes)
+    ItemEffect effect;
+    // offset 0010 (1 bytes)
+    int8_t quality_level;
+    // offset 0014 (4 bytes)
+    affix_item_type item_type_flags; // bitmask
+    // offset 0018 (4 bytes)
+    int excluded_combination; // contains 0x01 or 0x10. If (suffix | preffix) == 0x11 they will
+                              // never be applied to a single item simultaneously. Also if prefix
+                              // has value 0x01 it also means that it can not be present on a staff
+                              // with a spell.
+    // offset 001C (4 bytes)
+    bool32_t double_chance; // if it is set then there's a twice is likely chance that this affix
+                            // will be generated than if it's not
+    // offset 0020 (4 bytes)
+    bool32_t not_cursed; // cursed affixes are never applied to items sold in town and also have
+                         // lower probability to be applied in other cases.
+    // offset 0024 (4 bytes)
+    int min_price;
+    // offset 0028 (4 bytes)
+    int max_price;
+    // offset 002C (4 bytes)
+    int cost_multiplier;
+} ItemAffixData;
+
 // A Point is an X, Y coordinate pair. The axes increase right and down.
 typedef struct {
 	int32_t x;


### PR DESCRIPTION
These structs are mostly trivial but I found it a bit annoying that naming of their fields are a bit confusing in freeablo for example, so I think defining them is quite useful. Feel free to suggest a change for any name or explanation and correct my mistakes if I'm wrong.