### PR TITLE
2 tiny fixes

### DIFF
--- a/structs.h
+++ b/structs.h
@@ -922,7 +922,7 @@ typedef struct {
 	item_drop_state drop_state;
 	/// offset 0034 (4 bytes)
 	bool32_t draw_quest_item;
-	/// offset 0038 (1 byte)
+	/// offset 0038 (4 bytes)
 	bool32_t is_identified;
 	/// offset 003C (1 byte)
 	item_quality quality;

--- a/structs.h
+++ b/structs.h
@@ -3,6 +3,7 @@
 
 #include "typedefs.h"
 #include "enums.h"
+#include "windows.h"
 
 /// ActionFrame specifies the frame of each animation for which an action is
 /// triggered.

--- a/windows.h
+++ b/windows.h
@@ -1,3 +1,6 @@
+#ifndef WINDOWS_H
+#define WINDOWS_H
+
 /// ref: https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751(v=vs.85).aspx
 typedef uint8_t BYTE;
 typedef uint16_t WORD;
@@ -395,3 +398,5 @@ typedef struct {
 	BYTE peBlue;
 	BYTE peFlags;
 } PALETTEENTRY;
+
+#endif // WINDOWS_H


### PR DESCRIPTION
* size for `is_identified` in `Item`
* `windows.h` include in `structs.h` because it requires `WAVEFORMATEX` definition. I also added header guard just in case.