### PR TITLE
Fix array size

### DIFF
--- a/bss/items.cpp
+++ b/bss/items.cpp
@@ -2,5 +2,8 @@
 
 /// address: 0x635A28
 ///
+/// PSX ref: 0x800D1D54
+/// PSX def: ItemStruct item[128]
+///
 /// items contains the items on ground of the current game.
-Item items[127];
+Item items[128];


### PR DESCRIPTION
Although there are only 127 item slots, there is an extra slot (128) used as a temporary buffer.